### PR TITLE
On logout, direct user to previous page instead of login page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ yarn-error.log
 /.idea
 /.vscode
 .DS_Store
+data.ms

--- a/app/Http/Responses/LogoutResponse.php
+++ b/app/Http/Responses/LogoutResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Filament\Http\Responses\Auth\Contracts\LogoutResponse as Responsable;
+use Filament\Notifications\Notification;
+use Illuminate\Http\RedirectResponse;
+
+class LogoutResponse extends \Filament\Http\Responses\Auth\LogoutResponse
+{
+    public function toResponse($request): RedirectResponse
+    {
+
+        Notification::make('logged out')
+            ->success()
+            ->title('You have been logged out')
+            ->duration(5000)
+            ->send();
+
+        return redirect()->back();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use DutchCodingCompany\FilamentSocialite\Models\Contracts\FilamentSocialiteUser as FilamentSocialiteUserContract;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse;
+use Filament\Http\Responses\Auth\Contracts\LogoutResponse;
 use Filament\Http\Responses\Auth\Contracts\RegistrationResponse;
 use DutchCodingCompany\FilamentSocialite\Facades\FilamentSocialite;
 use Illuminate\Support\ServiceProvider;
@@ -17,6 +18,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(LoginResponse::class, \App\Http\Responses\LoginResponse::class);
+        $this->app->singleton(LogoutResponse::class, \App\Http\Responses\LogoutResponse::class);
         $this->app->singleton(RegistrationResponse::class, \App\Http\Responses\RegistrationResponse::class);
     }
 


### PR DESCRIPTION
fixes #49 

PR that takes the user back to the page they were on when they log out, assuming they are on the front-end. I added this because I was doing the same thing on Metrics (and copying the login / socialite system from here onto Metrics)

When logging out from the admin panel, they are still directed to the login page for the admin panel as normal. 

Could quickly be tweaked to always take the user back to the main front-page, which might be better for this app? 

